### PR TITLE
Pin bandit to mitigate for flake8-bandit

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,3 +12,6 @@ flake8-annotations~=2.0
 flake8-bandit~=2.1
 flake8-docstrings~=1.5
 flake8-isort~=4.0
+
+# Force due to https://github.com/PyCQA/bandit/issues/837
+bandit==1.7.2


### PR DESCRIPTION
When installing the dev-requirements running `flake8` gives

> TypeError: BanditNodeVisitor.__init__() missing 1 required positional argument: 'metrics'

- https://github.com/PyCQA/bandit/issues/837
- https://github.com/PyCQA/bandit/issues/841

This is easiest fixed by pinning on `bandit==1.7.2`

In https://github.com/PyCQA/bandit/issues/837#issuecomment-1054746340 `flake8-bandig` should not use a private API.

## Installing given dev-requirements

This pulls in `bandit==1.7.4` which does not fit with `flake-bandit==2.1.2`.

```shell
pip list
Package            Version
------------------ -------
attrs              21.4.0
bandit             1.7.4 <=====
cfgv               3.3.1
distlib            0.3.5
filelock           3.7.1
flake8             3.9.2
flake8-annotations 2.9.0
flake8-bandit      2.1.2
flake8-docstrings  1.6.0
flake8-isort       4.1.1
flake8-polyfill    1.0.2
gitdb              4.0.9
GitPython          3.1.27
identify           2.5.1
isort              5.10.1
mccabe             0.6.1
nodeenv            1.7.0
pbr                5.9.0
pip                22.1.2
platformdirs       2.5.2
pre-commit         2.13.0
pycodestyle        2.7.0
pydocstyle         6.1.1
pyflakes           2.3.1
PyYAML             6.0
setuptools         63.2.0
six                1.16.0
smmap              5.0.0
snowballstemmer    2.2.0
stevedore          4.0.0
testfixtures       6.18.5
toml               0.10.2
virtualenv         20.15.1
```